### PR TITLE
Add TLS encryption to Remotely Dockerfile

### DIFF
--- a/remotely/Dockerfile
+++ b/remotely/Dockerfile
@@ -6,7 +6,11 @@ MAINTAINER Arnaud Dartois <nonobis@gmail.com>
 # Set for all apt-get install, must be at the very beginning of the Dockerfile.	
 ENV DEBIAN_FRONTEND=noninteractive 
 ENV ASPNETCORE_ENVIRONMENT="Production"
-ENV ASPNETCORE_URLS http://*:5000
+ENV ASPNETCORE_URLS https://*:5000
+ENV ASPNETCORE_HTTPS_PORT=5000
+ENV ASPNETCORE_Kestrel__Certificates__Default__Path=/var/www/remotely/.aspnet/https/remotely.pfx
+ENV ASPNETCORE_Kestrel__Certificates__Default__Password=remotely
+
 
 ######################################################################################################################
 ########################################### Expose Port or Volumes ###################################################
@@ -14,27 +18,19 @@ EXPOSE 5000/tcp
 
 ######################################################################################################################
 ################################################# Install prerequisites ##############################################
-RUN apt-get update 
-RUN apt-get upgrade -y
-RUN apt-get -y install wget curl unzip acl ffmpeg libc6-dev libgdiplus
-RUN apt-get update	
-RUN apt-get -y install software-properties-common
+RUN apt-get update && apt-get upgrade -y && apt-get -y install wget curl unzip acl ffmpeg libc6-dev libgdiplus software-properties-common
 
 ######################################################################################################################
 ################################################# Install Net Core ###################################################
 
 # Install the .NET Core Repository
-RUN wget -q https://packages.microsoft.com/config/ubuntu/18.04/packages-microsoft-prod.deb
-RUN dpkg -i packages-microsoft-prod.deb
+RUN wget -q https://packages.microsoft.com/config/ubuntu/18.04/packages-microsoft-prod.deb && dpkg -i packages-microsoft-prod.deb
 
 # Install net-core dependency
-RUN apt-get update	
-RUN add-apt-repository universe
-RUN apt-get -y install apt-transport-https
+RUN apt-get update && add-apt-repository universe && apt-get -y install apt-transport-https
 
 # Install the .NET Core SDK
-RUN apt-get update	
-RUN apt-get -y  install dotnet-sdk-3.1
+RUN apt-get update && apt-get -y install dotnet-sdk-3.1
 
 ######################################################################################################################
 ################################ Download and Install Application ####################################################
@@ -44,6 +40,10 @@ RUN unzip -o Remotely_Server_Linux-x64.zip -d /var/www/remotely/
 RUN rm Remotely_Server_Linux-x64.zip
 RUN setfacl -R -m u:www-data:rwx /var/www/remotely/
 RUN chown -R www-data:www-data /var/www/remotely/
+
+# Generate https certificate
+RUN mkdir -p /var/www/remotely/.aspnet/https/ 
+RUN dotnet dev-certs https --clean && dotnet dev-certs https -ep /var/www/remotely/.aspnet/https/remotely.pfx -p "remotely"
 
 WORKDIR /var/www/remotely/
 VOLUME /var/www/remotely


### PR DESCRIPTION
Hi, I appreciate this Docker and am currently using it. I wanted my Remotely to use HTTPS instead of HTTP so I made the changes available if you would like to merge them. I also concatenated some commands together to reduce the number of layers and calls to apt update.